### PR TITLE
deepin-rescv64

### DIFF
--- a/sig/deepin-riscv64/MEMBERS.md
+++ b/sig/deepin-riscv64/MEMBERS.md
@@ -1,0 +1,21 @@
+<!--
+    小组组员列表
+
+    按小组实际情况编辑模板即可，下面的例子仅供参考。
+    
+    可以在这里以 Markdown 的形式列出组员信息。可以是昵称，可以在后面附加组员希望添加的其它信息（限一行内）
+    请注意，小组管理员 **必须** 提供 GitHub ID 以供外部联系
+-->
+
+## 小组管理员
+
+- [Zeno-sole](https://github.com/Zeno-sole)  
+- [tsic404](https://github.com/tsic404) 
+
+## 小组成员
+
+- [tsic404](https://github.com/tsic404) (Github)
+
+- [Clay Stan](https://github.com/ClayStan)  (Github)
+
+  

--- a/sig/deepin-riscv64/README.md
+++ b/sig/deepin-riscv64/README.md
@@ -1,0 +1,34 @@
+<!--
+
+请按照实际情况编辑此文件，以使内容适应您所要创建的 SIG 的实际情况，并在发起申请时删除此段注释。
+
+请注意：
+
+以下五段二级标题均为必须存在的段落。小组也可根据自身需求增加其它的段落和详细的描述，但不应删除此处的四个段落。
+
+-->
+
+# deepin-riscv64 SIG
+
+## 小组简介
+
+负责Deepin仓库RISC-V开源软件包的维护，进行软件包构建、系统构建、Bug修复等工作。
+
+## 活动范围与目标
+
+目标： 为deepin操作系统适配RISC-V架构,为RISC-V架构芯片提供更多的桌面应用。
+
+活动范围：[社区论坛](https://bbs.deepin.org/)、[邮件列表](https://www.freelists.org/list/deepin-riscv64)、[Telegram](https://t.me/+gayVJlNnqXNlYzM1)
+
+## 小组章程
+
+邮件列表发送月报公布工作进度以及当前问题，必要时进行线上会议讨论相关问题
+
+## 讨论渠道
+
+[邮件列表](https://www.freelists.org/list/deepin-riscv64)、[Telegram](https://t.me/+gayVJlNnqXNlYzM1)
+
+## 相关链接
+
+- [GitHub 上的小组团队](https://github.com/orgs/deepin-community/teams/deepin-riscv64)
+- [其它链接](在这里粘贴其它链接)


### PR DESCRIPTION
## 创建原因
为deepin操作系统适配RISC-V架构,为RISC-V架构芯片提供更多的桌面应用。

## 仓库创建
 [sig-deepin-riscv64](https://github.com/deepin-community/sig-deepin-riscv64)