### PR TITLE
[新 SIG 提案] deepin-m1

### DIFF
--- a/sig/deepin-m1/MEMBERS.md
+++ b/sig/deepin-m1/MEMBERS.md
@@ -1,0 +1,10 @@
+## 小组管理员
+
+- [justforlxz](https://github.com/justforlxz)
+- [tsic404](https://github.com/tsic404) 
+
+## 小组成员
+
+- [justforlxz](https://github.com/justforlxz)
+- [tsic404](https://github.com/tsic404) 
+

--- a/sig/deepin-m1/README.md
+++ b/sig/deepin-m1/README.md
@@ -1,0 +1,62 @@
+# deepin-m1 SIG
+
+## 小组简介
+
+负责将 deepin 移植到 Apple m1 硬件设备上运行，并维护相关开源软件包，进行软件包构建、系统构建、Bug修复等工作。
+
+## 活动范围与目标
+
+目标：为 deepin 操作系统适配 Apple m1 架构，为 m1 架构芯片提供更多的桌面应用。
+
+活动范围：[社区论坛](https://bbs.deepin.org/)、[邮件列表](https://www.freelists.org/list/deepin-m1)、[Telegram](https://t.me/deepin_m1)、[IRC](https://web.libera.chat/#deepin-m1)、[Matrix](https://matrix.to/#/#deepin-m1:matrix.org)
+
+## 如何加入
+
+### 加入标准： 
+
+1. 对硬件驱动反向有兴趣
+2. 掌握一定的开源驱动开发技能
+
+加入方法：
+
+1. 在[sig-deepin-m1](https://github.com/deepin-community/sig-deepin-m1/issues)提交issues 说明想加入的原因
+2. 订阅邮件列表
+3. 加入Telegram群组 / IRC / Matrix
+
+加入之后会在邮件列表进行公示
+
+##  repository
+
+[deepin-m1](https://github.com/linuxdeepin/deepin-m1)
+
+### 小组章程
+
+## 小组章程
+
+邮件列表发送月报公布工作进度以及当前问题，必要时进行线上会议讨论相关问题，会议议题以及会议时间会参与方式等信息会提前在邮件列表或者群组内进行公布。
+
+ps: 章程目前还不完善，有兴趣的同学可以加入进来讨论。 
+
+## 讨论渠道
+
+讨论渠道已通过 Matrix bridge 将 telegram 与 irc 连接起来，并不需要特意保持在某个讨论群组中。
+
+### Telegram
+
+[https://t.me/deepin_m1](https://t.me/deepin_m1)
+
+### IRC
+
+[https://web.libera.chat/#deepin-m1](https://web.libera.chat/#deepin-m1)
+
+### Matrix
+
+[https://matrix.to/#/#deepin-m1:matrix.org](https://matrix.to/#/#deepin-m1:matrix.org)
+
+### 邮件列表
+
+[https://www.freelists.org/list/deepin-m1](https://www.freelists.org/list/deepin-m1)
+
+## 相关链接
+
+- [GitHub 上的小组团队](https://github.com/orgs/deepin-community/teams/deepin-m1)


### PR DESCRIPTION
## 创建原因

将 deepin 操作系统移植到 Apple m1 芯片，并维护开源软件包的构建、修复以及更新。