### PR TITLE
[新 SIG 提案] deepin-sysdev-team

### DIFF
--- a/sig/deepin-sysdev-team/MEMBERS.md
+++ b/sig/deepin-sysdev-team/MEMBERS.md
@@ -1,0 +1,18 @@
+<!--
+    小组组员列表
+
+    按小组实际情况编辑模板即可，下面的例子仅供参考。
+
+    可以在这里以 Markdown 的形式列出组员信息。可以是昵称，可以在后面附加组员希望添加的其它信息（限一行内）
+    请注意，小组管理员 **必须** 提供 GitHub ID 以供外部联系
+-->
+
+## 小组管理员
+
+- [vench](https://github.com/venchh)
+- [gnefuh](https://github.com/gnefuh)
+
+## 小组成员
+
+- [venchh](https://github.com/venchh) (Github)
+- [gnefuh](https://github.com/gnefuh) (Github)

--- a/sig/deepin-sysdev-team/README.md
+++ b/sig/deepin-sysdev-team/README.md
@@ -1,0 +1,51 @@
+<!--
+
+请按照实际情况编辑此文件，以使内容适应您所要创建的 SIG 的实际情况，并在发起申请时删除此段注释。
+
+请注意：
+
+以下五段二级标题均为必须存在的段落。小组也可根据自身需求增加其它的段落和详细的描述，但不应删除此处的四个段落。
+
+-->
+# deepin通用软件打包小组
+
+## 小组简介
+
+负责Deepin仓库通用开源软件包的维护，进行软件包构建、Bug修复等工作
+
+## 活动范围与目标
+
+目标: 为Deepin操作系统提供通用软件包的维护，跟进版本更新和BUG修复工作，与软件上游保持积极良好的沟通。
+活动范围: [社区论坛](https://bbs.deepin.org/),[邮件列表](https://www.freelists.org/list/sig-deepin-sysdev-team)
+
+## 如何加入
+
+### 加入标准： 
+
+1.了解debian打包规则
+
+2.了解dpkg、debuild/pbuild等软件包管理、编译构建等工具
+
+3.熟悉Makefile cmake debian/rule等构建工具或构建规则的使用方法
+
+加入方法：
+
+1. 在[sig-deepin-sysdev-team](https://github.com/deepin-community/sig-deepin-sysdev-team/issues)提交issues 说明想加入的原因
+2. 订阅邮件列表
+
+加入之后会在邮件列表进行公示
+
+## 小组章程
+
+邮件列表发送月报公布工作进度以及当前问题，必要时进行线上会议讨论相关问题，会议议题以及会议时间会参与方式等信息会提前在邮件列表或者群组内进行公布。
+
+## 讨论渠道
+
+微信群、[邮箱列表](https://www.freelists.org/list/sig-deepin-sysdev-team)
+
+## 相关链接
+
+- [邮箱列表](https://www.freelists.org/list/sig-deepin-sysdev-team)
+- [deepin社区论坛](https://bbs.deepin.org/)
+- [GitHub 上的小组团队](https://github.com/deepin-community/sig-deepin-sysdev-team)
+


### PR DESCRIPTION
负责Deepin仓库通用开源软件包的维护，进行软件包构建、系统构建、Bug修复等工作

此 SIG 需在 deepin-community 组织下创建如下仓库：
- sig-deepin-sysdev-team