### PR TITLE
[新 SIG 提案] deepin-qt-team

### DIFF
--- a/sig/deepin-qt/MEMBERS.md
+++ b/sig/deepin-qt/MEMBERS.md
@@ -1,0 +1,10 @@
+## 小组管理员
+
+- [NSUTanghaixiang](https://github.com/NSUTanghaixiang)
+- [Dami-star](https://github.com/Dami-star) 
+
+## 小组成员
+
+- [NSUTanghaixiang](https://github.com/NSUTanghaixiang)
+- [Dami-star](https://github.com/Dami-star) 
+

--- a/sig/deepin-qt/README.md
+++ b/sig/deepin-qt/README.md
@@ -1,0 +1,42 @@
+# deepin-qt SIG
+
+## 小组简介
+
+负责 deepin 、debian系统上 Qt 软件打包与维护，跟进上游版本以及BUG修复，参与Qt上游社区建设等工作，欢迎所有热爱Qt，热爱开源的人加入。
+
+## 活动范围与目标
+
+目标：在 deepin、debian 上不影响兼容的前提下，对 Qt 现有版本进行维护，包括 BUG 修复、新功能开发、打包等工作。为下一个系统版本进行 Qt 选型、迁移等工作。参与 Qt 上游社区建设、包括在 Qt 论坛、bugreports 解答问题、帮助新人贡献补丁、修复上游 BUG、新功能开发等。
+
+活动范围：[deepin-community](https://github.com/deepin-community/sig-deepin-qt)、[邮件列表](deepin-qt-team@freelists.org)
+
+## 如何加入
+
+### 加入标准： 
+
+1. 熟悉 Qt 某个模块工作原理
+2. 了解开源协议
+2. 熟悉 debian 打包规则
+
+加入方法：
+
+1. 在[sig-deepin-qt ](https://github.com/deepin-community/sig-deepin-qt/issues)提交issues 说明想加入的原因
+2. 订阅邮件列表
+
+加入之后会在邮件列表进行公示
+
+## 小组章程
+
+* 本着开源为快乐的原则，我们欢迎所有热爱Qt，热爱开源的人加入，如果做这件事情无法为你带来满足和快乐，请不要继续。
+* 允许随时加入和退出，来时不问壮士出处，去时不问英雄何故。
+* 通过向[此项目](https://github.com/NSUTanghaixiang/SIG/tree/master/sig/deepin-qt)提交PR，修改其 [MEMBERS.md](https://github.com/NSUTanghaixiang/SIG/blob/master/sig/deepin-qt/MEMBERS.md) 中的成员列表来申请加入。反之则退出。
+* 一般情况，在不影响兼容的情况下，只接受 Qt 官方的补丁合入。对于一些影响兼容的，但是又非常重要的，我们会特殊对待。在向我们贡献代码的时候，请附带上官方补丁链接。
+* 如何向 debian 或者 Qt 官方贡献代码，请阅读他们的贡献准则
+
+## 讨论渠道
+
+目前讨论渠道仅限于[此项目](https://github.com/NSUTanghaixiang/SIG/tree/master/sig/deepin-qt)和 [邮件列表 ](https://www.freelists.org/list/deepin-qt)，请尽情的蹂躏它们，如果某一天它们承受不住，我们会考虑其他的讨论渠道。
+
+## 相关链接
+
+- [GitHub 上的小组团队](https://github.com/orgs/deepin-community/teams/deepin-qt)

--- a/sig/deepin-qt/README.md
+++ b/sig/deepin-qt/README.md
@@ -39,4 +39,4 @@
 
 ## 相关链接
 
-- [GitHub 上的小组团队](https://github.com/orgs/deepin-community/teams/deepin-qt)
+- [GitHub 上的小组仓库](https://github.com/deepin-community/sig-deepin-qt)


### PR DESCRIPTION
 ## 创建原因

 负责 deepin 、debian系统上 Qt 软件打包与维护，跟进上游版本以及BUG修复，参与Qt上游社区建设等

 ## 仓库创建

 此 SIG 需在 deepin-community 组织下创建如下仓库：
 - sig-deepin-qt