### PR TITLE
Add deepin Intel-SIG

### DIFF
--- a/sig/deepin-Intel/MEMBERS.md
+++ b/sig/deepin-Intel/MEMBERS.md
@@ -1,0 +1,10 @@
+## 小组管理员
+
+- [quanxianwang](https://github.com/quanxianwang)
+
+## 小组成员
+
+- [quanxianwang](https://github.com/quanxianwang)
+- [Baolizha](https://github.com/Baolizha)
+
+

--- a/sig/deepin-Intel/README.md
+++ b/sig/deepin-Intel/README.md
@@ -1,0 +1,46 @@
+# deepin Intel 小组 
+
+## 小组简介
+
+Intel will continually release new platform and keep sync with upstream and deepin OS based on customer request.
+Also Intel will bring more features into deepin OS such as openVino, oneAPI, Intel GPUs if possible.
+Intel will cooperate with deepin community to support OEMs including Dell, HP, Lenovo and more to support Intel platforms.
+
+负责Intel platform的维护和更新工作。
+
+## 活动范围与目标
+
+目标：对Intel platform的维护和更新，跟进上游版本以及BUG修复，参与Intel platform上游社区建设等工作, 保证维护的及时、安全、可靠。
+
+活动范围: [社区论坛](https://bbs.deepin.org/)[deepin Community](https://github.com/deepin-community/) [GitHub issue](https://github.com/linuxdeepin/developer-center/issues) [deepin-Intel](https://github.com/deepin-community/sig-deepin-Intel)
+
+## 如何加入
+
+### 加入标准：
+
+1. 熟悉 Intel platform
+2. 了解开源协议
+2. 熟悉 debian 打包规则
+
+### 加入方法：
+
+1. 在[sig-deepin-Intel](https://github.com/deepin-community/sig-deepin-Intel/issues)提交issues 说明想加入的原因
+2. 订阅邮件列表 [deepin-Intel](https://www.freelists.org/list/deepin-Intel)
+
+加入之后会在邮件列表进行公示
+
+## 小组章程
+
+欢迎所有对Intel platform感兴趣的爱好者加入。
+我们希望建立一个友好开放包容的交流环境，让所有热爱Deepin社区、热爱技术的任何人能够一起交流学习。
+允许随时加入和退出，来时不问壮士出处，去时不问英雄何故，但我们会定期对长期不活跃成员进行处理。
+对于向deepin贡献代码/软件包等章程请遵循其官方文档，这里不再赘述。
+
+
+## 讨论渠道
+
+在[deepin-Intel](https://github.com/deepin-community/sig-deepin-Intel)项目的[ISSUE区](https://github.com/deepin-community/sig-deepin-Intel/issues)进行主要的讨论。
+
+## 相关链接
+
+- [GitHub 上的小组团队](https://github.com/orgs/deepin-community/teams/sig-deepin-Intel)

--- a/sig/deepin-Intel/metadata.yml
+++ b/sig/deepin-Intel/metadata.yml
@@ -1,0 +1,21 @@
+---
+name: deepin Intel 小组
+blog:
+rss:
+proposal:
+  issue:
+  by:
+    handle: quanxianwang
+    id: 803339
+date-created: '2024/01/01'
+date-archived: '-'
+team: sig-deepin-Intel
+repos:
+  maintained:
+    - sig-deepin-Intel
+  package:
+members:
+  - handle: quanxianwang
+    id: 803339
+  - handle: Baolizha
+    id: 29588229


### PR DESCRIPTION
Intel will take part in deepin OS community as a whole. 

- We will focus on Intel platform enabling and related Intel features including AI, dGPU, oneAPI, openVino if possible.
- Intel will continually release new platforms and keep sync with upstream and deepin OS based on customer request.
- if possible, Intel will cooperate with deepin community to support OEMs including Dell, HP, Lenovo and more to support Intel platforms.