### PR TITLE
fix: typo

### DIFF
--- a/sig/deepin-Intel/events.yaml
+++ b/sig/deepin-Intel/events.yaml
@@ -12,7 +12,7 @@ events:
   actor_handle: shiqingd
   created_at: 2024-01-08 03:05:31+00:00
 - type: join
-  actor_id: 82864339b
+  actor_id: 82864339
   actor_handle: yifanli-intel
   created_at: 2024-01-08 03:05:31+00:00
 - type: join


### PR DESCRIPTION
修复id包含异常字符

Log: