### PR TITLE
[新SIG提案] deepin-security SIG

### DIFF
--- a/sig/deepin-security/MEMBERS.md
+++ b/sig/deepin-security/MEMBERS.md
@@ -1,0 +1,7 @@
+## 小组成员
+
+- [jingfelix](https://github.com/jingfelix)
+- [mudongliang](https://github.com/mudongliang)
+- [huyinhao](https://github.com/huyinhao)
+- [wumingzhilian](https://github.com/wumingzhilian)
+- [SophieTwilight](https://github.com/SophieTwilight)

--- a/sig/deepin-security/README.md
+++ b/sig/deepin-security/README.md
@@ -1,0 +1,43 @@
+# deepin security SIG
+
+## 小组介绍
+
+deepin-security 小组旨在帮助保护与提升 deepin 的系统安全性。我们使用多种安全工具对 deepin 内核与系统组件进行测试，帮助查找系统中的漏洞。同时，我们也会对使用的安全组件配置和安全规则提出合理的建议，帮助提升 deepin 的系统安全性。
+
+## 活动范围与目标
+
+我们的活动旨在：
+
+- 对 deepin 内核及其他系统组件进行长期安全测试，帮助查找系统中的漏洞。
+
+- 不定期举行安全分享，交流安全知识。
+
+- 审计 deepin 中使用的安全组件配置和安全规则，提出合理的建议。
+
+## 小组章程
+
+ 欢迎对 deepin 安全感兴趣的同学加入我们，我们会定期组织安全测试，分享安全知识，帮助提升 deepin 的系统安全性。
+
+我们希望你：
+
+1. 对操作系统安全有一定的了解。
+
+2. 有一定的安全测试经验，包括但不限于各种形式的静态与动态测试。
+
+3. 了解 Linux 内核补丁贡献流程。
+
+4. 愿意付出时间和精力，参与到 deepin 安全测试中。
+
+5. 具有良好的安全意识，及时向团队或社区反馈发现的安全问题。
+
+加入流程：
+
+1. 向 [openatom_club@hust.edu.cn](mailto:openatom_club@hust.edu.cn) 发送邮件，标明申请加入 deepin-security SIG，并简单介绍申请加入的原因。
+
+## 讨论渠道
+
+使用这个[链接](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=8a9qd4a8-2870-44b5-8dbe-02831031acc7)加入飞书群组
+
+## 相关链接
+
+华中科技大学开放原子开源俱乐部：[hust.openatom.club](https://hust.openatom.club/)

--- a/sig/deepin-security/metadata.yml
+++ b/sig/deepin-security/metadata.yml
@@ -1,0 +1,27 @@
+---
+name: deepin-security-sig deepin安全小组
+blog: 
+rss: 
+matrix: 
+proposal:
+  by:
+    handle: jingfelix
+    id: 72600955
+date-created: '2024/05/21'
+date-archived: '-'
+team: deepin-security
+repos:
+  maintained:
+  package:
+    - hustmirror-cli
+members:
+  - handle: jingfelix
+    id: 72600955
+  - handle: mudongliang
+    id: 6214861
+  - handle: huyinhao
+    id: 45302845
+  - handle: SophieTwilight
+    id: 53810827
+  - handle: wumingzhilian
+    id: 69114599


### PR DESCRIPTION
## 创建原因

创建 deepin-security SIG 的目的在于保护与提升 deepin 的系统安全性。我们通过静态检测，模糊测试等方式，对deepin 内核与系统组件进行测试，帮助查找系统中的漏洞。同时，通过对使用的安全组件配置和安全规则提出合理的建议，我们帮助提升 deepin 的系统安全性。