### PR TITLE
chore: update sig repo link

### DIFF
--- a/sig/deepin-raspberrypi/README.md
+++ b/sig/deepin-raspberrypi/README.md
@@ -46,4 +46,4 @@
 
 ## 相关链接
 
-- [GitHub 上的小组仓库](https://github.com/deepin-community/sig-deepin-raspberrypi)
+- [GitHub 上的小组仓库](https://github.com/deepin-community/deepin-raspberrypi)


### PR DESCRIPTION
Update the repository link for sig-deepin-raspberrypi

Log: update sig repo link