### PR TITLE
chore: Add ZGC-Lab SIG

### DIFF
--- a/corporation/Phytium/events.yaml
+++ b/corporation/Phytium/events.yaml
@@ -83,3 +83,31 @@ events:
   actor_id: 62878031
   actor_handle: MendezShuai
   created_at: 2024-12-17 11:20:39+00:00
+- type: join
+  actor_id: 168501409
+  actor_handle: wangzhimin1179
+  created_at: 2025-01-20 03:13:19+00:00
+- type: join
+  actor_id: 56667401
+  actor_handle: yuanxia0927
+  created_at: 2025-01-20 03:13:19+00:00
+- type: join
+  actor_id: 66865136
+  actor_handle: studyhu
+  created_at: 2025-01-20 03:13:19+00:00
+- type: join
+  actor_id: 61820402
+  actor_handle: hhhui-L
+  created_at: 2025-01-20 03:13:19+00:00
+- type: join
+  actor_id: 73590715
+  actor_handle: lyt31
+  created_at: 2025-01-20 03:13:19+00:00
+- type: join
+  actor_id: 132661023
+  actor_handle: JiakunShuai
+  created_at: 2025-01-20 03:13:19+00:00
+- type: leave
+  actor_id: 62878031
+  actor_handle: MendezShuai
+  created_at: 2025-01-20 03:13:19+00:00

--- a/corporation/UnionTech/events.yaml
+++ b/corporation/UnionTech/events.yaml
@@ -1383,3 +1383,19 @@ events:
   actor_id: 142064413
   actor_handle: USFunction
   created_at: 2025-01-14 03:39:20+00:00
+- type: join
+  actor_id: 65995538
+  actor_handle: dxnu
+  created_at: 2025-01-20 03:13:19+00:00
+- type: join
+  actor_id: 186556556
+  actor_handle: dengzhongyuan365-dev
+  created_at: 2025-01-20 03:13:19+00:00
+- type: join
+  actor_id: 142064413
+  actor_handle: USFunction
+  created_at: 2025-01-20 03:13:19+00:00
+- type: join
+  actor_id: 102841447
+  actor_handle: xiongq0903
+  created_at: 2025-01-20 03:13:19+00:00

--- a/sig/MakerFrame/events.yaml
+++ b/sig/MakerFrame/events.yaml
@@ -1,0 +1,9 @@
+events:
+- type: join
+  actor_id: 52902574
+  actor_handle: leamus
+  created_at: 2025-01-20 03:13:19+00:00
+- type: join
+  actor_id: 22316465
+  actor_handle: Archer
+  created_at: 2025-01-20 03:13:19+00:00

--- a/sig/ZGC-Lab/MEMBERS.md
+++ b/sig/ZGC-Lab/MEMBERS.md
@@ -1,0 +1,6 @@
+## 小组成员
+
+- [amjac](https://github.com/IamJustaChild)
+- [Avenger-285714](https://github.com/Avenger-285714)
+- [Dong Li](https://github.com/leeeastwood)
+- [Zhe Wang](https://github.com/zhexwang)

--- a/sig/ZGC-Lab/README.md
+++ b/sig/ZGC-Lab/README.md
@@ -1,0 +1,35 @@
+# ZGC-Lab SIG - 中关村实验室deepin特别兴趣小组
+
+## 小组简介
+
+ZGC-Lab SIG在deepin社区负责基于HAOC Linux等项目与deepin内核团队共同建设和维护安全增强Linux内核。
+
+## 活动范围与目标
+
+1.提交并维护HAOC内核安全增强补丁代码。
+2.HAOC安全增强补丁的完善，包括bugfix和对更多架构的适配等。
+3.其它与Linux内核安全有关的交流与合作。
+
+## 小组章程
+
+欢迎对Linux内核安全方向感兴趣的同学加入。
+
+### 加入标准：
+
+1. 熟悉Linux操作系统且对开源社区有浓厚的兴趣。
+2. 熟悉Linux内核的开发。
+3. 熟悉C语言且有相关的开发经验。
+4. 需要有安全行业相关的经验。
+
+### 加入方法：
+
+发送邮件至本SIG管理员邮箱：李栋<lidong@ict.ac.cn>
+
+### 讨论渠道
+
+[GitHub 上的小组仓库](https://github.com/deepin-community/sig-ZGC-Lab)
+
+
+### 相关链接
+
+- [GitHub 上的小组仓库](https://github.com/deepin-community/sig-ZGC-Lab)

--- a/sig/ZGC-Lab/metadata.yml
+++ b/sig/ZGC-Lab/metadata.yml
@@ -1,0 +1,22 @@
+name: ZGC-Lab
+blog:
+rss:
+matrix:
+proposal:
+  by:
+    handle: Dong Li
+    id: 1856763
+date-created: '2025/01/20'
+date-archived: '-'
+team: ZGC-Lab
+repos:
+  maintained:
+    - ZGC-Lab
+  package:
+members:
+  - handle: amjac
+    id: 97717986
+  - handle: Avenger-285714
+    id: 60058876
+  - handle: Zhe Wang
+    id: 10590787

--- a/sig/deepin-security/events.yaml
+++ b/sig/deepin-security/events.yaml
@@ -35,3 +35,15 @@ events:
   actor_id: 48875845
   actor_handle: alongnice
   created_at: 2025-01-01 07:09:10+00:00
+- type: join
+  actor_id: 64474767
+  actor_handle: gogolovefish
+  created_at: 2025-01-20 03:13:19+00:00
+- type: leave
+  actor_id: 50387785
+  actor_handle: neo-one0873
+  created_at: 2025-01-20 03:13:19+00:00
+- type: leave
+  actor_id: 48875845
+  actor_handle: alongnice
+  created_at: 2025-01-20 03:13:19+00:00


### PR DESCRIPTION
基于deepin内核研发团队和中关村实验室建立的合作关系，成立ZGC-Lab SIG以推进双方基于Linux内核安全加固方面更多的合作交流。