### PR TITLE
Delete sig/deepin-ThemeDesign directory

### DIFF
--- a/sig/deepin-ThemeDesign/metadata.yml
+++ b/sig/deepin-ThemeDesign/metadata.yml
@@ -8,7 +8,7 @@ proposal:
     handle: thatleosky
     id: 103563314
 date-created: '2023/12/22'
-date-archived: '-'
+date-archived: '2025/05/13'
 team: deepin-ThemeDesign
 repos:
   maintained:


### PR DESCRIPTION
因个人精力有限，无法继续承担主题壁纸 SIG 组的经营管理工作，现申请解散该组